### PR TITLE
Replace string concatenation with os path join

### DIFF
--- a/benchmark/start.py
+++ b/benchmark/start.py
@@ -56,10 +56,10 @@ def start_worker(config, machines):
     command = [
         "ansible-playbook",
         "-i",
-        config["infrastructure"]["base_path"] + "/.continuum/inventory_vms",
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory_vms"),
         "--extra-vars",
         vars_str[:-1],
-        config["infrastructure"]["base_path"] + "/.continuum/launch_benchmark.yml",
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/launch_benchmark.yml"),
     ]
     main.ansible_check_output(machines[0].process(config, command))
 
@@ -297,9 +297,7 @@ def start_endpoint(config, machines):
                 + [
                     "--name",
                     cont_name,
-                    config["registry"]
-                    + "/"
-                    + config["images"][1 + (int(config["mode"] == "endpoint"))].split(":")[1],
+                    os.path.join(config["registry"], config["images"][1 + (int(config["mode"] == "endpoint"))].split(":")[1]),
                 ]
             )
 

--- a/infrastructure/qemu/start.py
+++ b/infrastructure/qemu/start.py
@@ -41,8 +41,8 @@ def os_image(config, machines):
         command = [
             "ansible-playbook",
             "-i",
-            config["infrastructure"]["base_path"] + "/.continuum/inventory",
-            config["infrastructure"]["base_path"] + "/.continuum/infrastructure/os.yml",
+            os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory"),
+            os.path.join(config["infrastructure"]["base_path"], ".continuum/infrastructure/os.yml"),
         ]
         main.ansible_check_output(machines[0].process(config, command))
 
@@ -91,32 +91,29 @@ def base_image(config, machines):
             command = [
                 "ansible-playbook",
                 "-i",
-                config["infrastructure"]["base_path"] + "/.continuum/inventory",
-                config["infrastructure"]["base_path"] + "/.continuum/infrastructure/base_start.yml",
+                os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory"),
+                os.path.join(config["infrastructure"]["base_path"], ".continuum/infrastructure/base_start.yml"),
             ]
         elif "base_cloud" in base_name:
             command = [
                 "ansible-playbook",
                 "-i",
-                config["infrastructure"]["base_path"] + "/.continuum/inventory",
-                config["infrastructure"]["base_path"]
-                + "/.continuum/infrastructure/base_cloud_start.yml",
+                os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory"),
+                os.path.join(config["infrastructure"]["base_path"], ".continuum/infrastructure/base_cloud_start.yml"),
             ]
         elif "base_edge" in base_name:
             command = [
                 "ansible-playbook",
                 "-i",
-                config["infrastructure"]["base_path"] + "/.continuum/inventory",
-                config["infrastructure"]["base_path"]
-                + "/.continuum/infrastructure/base_edge_start.yml",
+                os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory"),
+                os.path.join(config["infrastructure"]["base_path"], ".continuum/infrastructure/base_edge_start.yml"),
             ]
         elif "base_endpoint" in base_name:
             command = [
                 "ansible-playbook",
                 "-i",
-                config["infrastructure"]["base_path"] + "/.continuum/inventory",
-                config["infrastructure"]["base_path"]
-                + "/.continuum/infrastructure/base_endpoint_start.yml",
+                os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory"),
+                os.path.join(config["infrastructure"]["base_path"], ".continuum/infrastructure/base_endpoint_start.yml"),
             ]
 
         main.ansible_check_output(machines[0].process(config, command))
@@ -169,22 +166,22 @@ def base_image(config, machines):
             command = [
                 "ansible-playbook",
                 "-i",
-                config["infrastructure"]["base_path"] + "/.continuum/inventory_vms",
-                config["infrastructure"]["base_path"] + "/.continuum/cloud/base_install.yml",
+                os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory_vms"),
+                os.path.join(config["infrastructure"]["base_path"], ".continuum/cloud/base_install.yml"),
             ]
         elif "base_edge" in base_name:
             command = [
                 "ansible-playbook",
                 "-i",
-                config["infrastructure"]["base_path"] + "/.continuum/inventory_vms",
-                config["infrastructure"]["base_path"] + "/.continuum/edge/base_install.yml",
+                os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory_vms"),
+                os.path.join(config["infrastructure"]["base_path"], ".continuum/edge/base_install.yml"),
             ]
         elif "base_endpoint" in base_name:
             command = [
                 "ansible-playbook",
                 "-i",
-                config["infrastructure"]["base_path"] + "/.continuum/inventory_vms",
-                config["infrastructure"]["base_path"] + "/.continuum/endpoint/base_install.yml",
+                os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory_vms"),
+                os.path.join(config["infrastructure"]["base_path"], ".continuum/endpoint/base_install.yml"),
             ]
 
         if command != []:
@@ -200,8 +197,8 @@ def base_image(config, machines):
     command = [
         "ansible-playbook",
         "-i",
-        config["infrastructure"]["base_path"] + "/.continuum/inventory_vms",
-        config["infrastructure"]["base_path"] + "/.continuum/infrastructure/netperf.yml",
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory_vms"),
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/infrastructure/netperf.yml"),
     ]
     main.ansible_check_output(machines[0].process(config, command))
 
@@ -339,8 +336,8 @@ def start(config, machines):
     command = [
         "ansible-playbook",
         "-i",
-        config["infrastructure"]["base_path"] + "/.continuum/inventory",
-        config["infrastructure"]["base_path"] + "/.continuum/infrastructure/remove.yml",
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory"),
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/infrastructure/remove.yml"),
     ]
     main.ansible_check_output(machines[0].process(config, command))
 
@@ -353,8 +350,8 @@ def start(config, machines):
         command = [
             "ansible-playbook",
             "-i",
-            config["infrastructure"]["base_path"] + "/.continuum/inventory",
-            config["infrastructure"]["base_path"] + "/.continuum/infrastructure/cloud_start.yml",
+            os.path.join(config["infrastructure"]["base_path"],".continuum/inventory"),
+            os.path.join(config["infrastructure"]["base_path"], ".continuum/infrastructure/cloud_start.yml"),
         ]
         main.ansible_check_output(machines[0].process(config, command))
 
@@ -363,8 +360,8 @@ def start(config, machines):
         command = [
             "ansible-playbook",
             "-i",
-            config["infrastructure"]["base_path"] + "/.continuum/inventory",
-            config["infrastructure"]["base_path"] + "/.continuum/infrastructure/edge_start.yml",
+            os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory"),
+            os.path.join(config["infrastructure"]["base_path"], ".continuum/infrastructure/edge_start.yml"),
         ]
         main.ansible_check_output(machines[0].process(config, command))
 
@@ -373,8 +370,8 @@ def start(config, machines):
         command = [
             "ansible-playbook",
             "-i",
-            config["infrastructure"]["base_path"] + "/.continuum/inventory",
-            config["infrastructure"]["base_path"] + "/.continuum/infrastructure/endpoint_start.yml",
+            os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory"),
+            os.path.join(config["infrastructure"]["base_path"], ".continuum/infrastructure/endpoint_start.yml"),
         ]
         main.ansible_check_output(machines[0].process(config, command))
 

--- a/resource_manager/endpoint/start.py
+++ b/resource_manager/endpoint/start.py
@@ -23,7 +23,7 @@ def start(config, machines):
     command = [
         "ansible-playbook",
         "-i",
-        config["infrastructure"]["base_path"] + "/.continuum/inventory_vms",
-        config["infrastructure"]["base_path"] + "/.continuum/endpoint/install.yml",
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory_vms"),
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/endpoint/install.yml"),
     ]
     main.ansible_check_output(machines[0].process(config, command))

--- a/resource_manager/kubeedge/start.py
+++ b/resource_manager/kubeedge/start.py
@@ -27,8 +27,8 @@ def start(config, machines):
         command = [
             "ansible-playbook",
             "-i",
-            config["infrastructure"]["base_path"] + "/.continuum/inventory_vms",
-            config["infrastructure"]["base_path"] + "/.continuum/edge/install_mist.yml",
+            os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory_vms"),
+            os.path.join(config["infrastructure"]["base_path"], ".continuum/edge/install_mist.yml"),
         ]
         processes.append(machines[0].process(config, command, output=False))
 
@@ -44,8 +44,8 @@ def start(config, machines):
     command = [
         "ansible-playbook",
         "-i",
-        config["infrastructure"]["base_path"] + "/.continuum/inventory_vms",
-        config["infrastructure"]["base_path"] + "/.continuum/cloud/control_install.yml",
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory_vms"),
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/cloud/control_install.yml"),
     ]
     processes.append(machines[0].process(config, command, output=False))
 
@@ -53,8 +53,8 @@ def start(config, machines):
     command = [
         "ansible-playbook",
         "-i",
-        config["infrastructure"]["base_path"] + "/.continuum/inventory_vms",
-        config["infrastructure"]["base_path"] + "/.continuum/edge/install.yml",
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory_vms"),
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/edge/install.yml"),
     ]
     processes.append(machines[0].process(config, command, output=False))
 
@@ -72,16 +72,16 @@ def start(config, machines):
         [
             "ansible-playbook",
             "-i",
-            config["infrastructure"]["base_path"] + "/.continuum/inventory_vms",
-            config["infrastructure"]["base_path"] + "/.continuum/cloud/control_log.yml",
+            os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory_vms"),
+            os.path.join(config["infrastructure"]["base_path"], ".continuum/cloud/control_log.yml"),
         ]
     )
     commands.append(
         [
             "ansible-playbook",
             "-i",
-            config["infrastructure"]["base_path"] + "/.continuum/inventory_vms",
-            config["infrastructure"]["base_path"] + "/.continuum/edge/log.yml",
+            os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory_vms"),
+            os.path.join(config["infrastructure"]["base_path"], ".continuum/edge/log.yml"),
         ]
     )
 

--- a/resource_manager/kubernetes/start.py
+++ b/resource_manager/kubernetes/start.py
@@ -25,8 +25,8 @@ def start(config, machines):
     command = [
         "ansible-playbook",
         "-i",
-        config["infrastructure"]["base_path"] + "/.continuum/inventory_vms",
-        config["infrastructure"]["base_path"] + "/.continuum/cloud/control_install.yml",
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory_vms"),
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/cloud/control_install.yml"),
     ]
     processes.append(machines[0].process(config, command, output=False))
 
@@ -34,8 +34,8 @@ def start(config, machines):
     command = [
         "ansible-playbook",
         "-i",
-        config["infrastructure"]["base_path"] + "/.continuum/inventory_vms",
-        config["infrastructure"]["base_path"] + "/.continuum/cloud/install.yml",
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/inventory_vms"),
+        os.path.join(config["infrastructure"]["base_path"], ".continuum/cloud/install.yml"),
     ]
     processes.append(machines[0].process(config, command, output=False))
 

--- a/scripts/replicate_model.py
+++ b/scripts/replicate_model.py
@@ -106,7 +106,7 @@ class Model:
 
             if dt >= self.resume:
                 if index == self.resume_index:
-                    path = log_location + "/" + log
+                    path = os.path.join(log_location, log)
                     logging.info("File %s for experiment run %i" % (path, index))
 
                     f = open(path, "r")

--- a/scripts/replicate_paper.py
+++ b/scripts/replicate_paper.py
@@ -58,7 +58,7 @@ class Experiment:
             dt = datetime.datetime.strptime(dt, "%Y-%m-%d_%H:%M:%S")
 
             if dt >= self.resume:
-                path = log_location + "/" + log
+                path = os.path.join(log_location, log)
                 logging.info("File %s for experiment run %i" % (path, exp_i))
 
                 f = open(path, "r")


### PR DESCRIPTION
The project used string concatenation to join paths. I have replace a lot, if not all, occurrences of that with os.path.join.
This fixes the issue that there were often pathes with double "/"