### PR TITLE
Fixing verify_options() in image_classification.py

### DIFF
--- a/application/image_classification/image_classification.py
+++ b/application/image_classification/image_classification.py
@@ -58,7 +58,7 @@ def verify_options(parser, config):
         parser.error("ERROR: image_classification app does not support application caching")
     elif config["benchmark"]["resource_manager"] == "kubecontrol":
         parser.error("ERROR: Application image_classification does not support kubecontrol")
-    elif config["benchmark"]["endpoint_nodes"] <= 0:
+    elif config["infrastructure"]["endpoint_nodes"] <= 0:
         parser.error("ERROR: Application image classification requires at least 1 endpoint")
 
 


### PR DESCRIPTION
verify_options() checks the "infrastructure" section of configurations for the "endpoint_nodes" field instead of the "benchmark" section, which caused execution failure on image classification benchmarks.