### PR TITLE
start_worker() unpack None TypeError fix

### DIFF
--- a/resource_manager/kubernetes/kubernetes.py
+++ b/resource_manager/kubernetes/kubernetes.py
@@ -622,7 +622,7 @@ def start_worker_kube(config, machines, app_vars, get_starttime):
     if get_starttime:
         return launch_with_starttime(config, machines)
 
-    return None
+    return (None, None)
 
 
 def start_worker_mist(config, machines, app_vars):


### PR DESCRIPTION
Changed return value of start_worker_kube() to "(None, None)" instead of None to avoid said error. Note that I've only tested this on my own branch which has some slight differences, because the cluster I've been running Continuum on was down at the moment of creating this PR.